### PR TITLE
New project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "wentwrong-hw",
+  "name": "gh-canary",
   "version": "1.0.0",
-  "description": "Awesome app",
+  "description": "Dashboard for github PR bot notifier",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "start-debug": "cross-env DEBUG=wentwrong-hw:* npm run start",
+    "start-debug": "cross-env DEBUG=gh-canary:* npm run start",
     "lint": "eslint src test",
     "test": "npm run lint && mocha test/**/*-test.js",
-    "test-debug": "cross-env DEBUG=wentwrong-hw:* npm test",
+    "test-debug": "cross-env DEBUG=gh-canary:* npm test",
     "watch": "npm test -- -w",
     "lint-fix": "npm run lint -- --fix"
   },

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,6 +1,6 @@
 const debug = require('debug');
 
 module.exports = {
-    log:   debug('wentwrong-hw:log'),
-    error: debug('wentwrong-hw:error')
+    log:   debug('gh-canary:log'),
+    error: debug('gh-canary:error')
 };


### PR DESCRIPTION
# A proposal to name the project as 'gh-canary'

Project should behave as a dashboard for the github bot that will keep track a given repositories for pull-requests from individual developers (non-team), mark that PRs by labels and to mention any of maintainers.

## Requirements
- REST API;
- Gulp + Typescript + Mocha (unit) + Testcafe (e2e);
- Fake github API endpoints for testing;
- Use github API for bot auth, fetching PRs and commenting/label assignment.

## User stories
**User story №1:** On the main page, I can see a pretty-view table (or another visual form) with new PRs.
**User story №2:** On the main page, I can manually modify auto-assigned labels and bot-comment.
**User story №3:** On the settings page, I can specify repositories on whose PRs i'd like to follow on.
**User story №4:** On the settings page, I can specify comment template and maintainers to mention.

## Draft suggestions
- Assign PRs to maintainers based on his contribution history to project?
- Assign PRs labels based on modified subsystems?
- Assign PRs labels based on keywords in comment?